### PR TITLE
Make constructor accepts a wallet interface instead of the type NodeW…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clockwork-xyz/sdk",
   "author": "Clockwork",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Clockwork Typescript SDK",
   "license": "MIT",
   "homepage": "https://github.com/clockwork-xyz/sdk",

--- a/src/ClockworkProvider.ts
+++ b/src/ClockworkProvider.ts
@@ -3,6 +3,7 @@ import {
   ConfirmOptions,
   Connection,
   PublicKey,
+  Transaction,
   TransactionInstruction
 } from "@solana/web3.js";
 
@@ -19,12 +20,21 @@ import {
   parseTransactionInstructions,
 } from "./utils";
 
+/**
+ * Wallet interface for objects that can be used to sign provider transactions.
+ */
+export interface ClockworkProviderWallet {
+  signTransaction(tx: Transaction): Promise<Transaction>;
+  signAllTransactions(txs: Transaction[]): Promise<Transaction[]>;
+  publicKey: PublicKey;
+}
+
 class ClockworkProvider {
   threadProgram: anchor.Program<ThreadProgram>;
   networkProgram: anchor.Program<NetworkProgram>;
 
   constructor(
-    wallet: anchor.Wallet,
+    wallet: ClockworkProviderWallet,
     connection: Connection,
     opts: ConfirmOptions = anchor.AnchorProvider.defaultOptions()
   ) {
@@ -39,6 +49,20 @@ class ClockworkProvider {
       NetworkProgramIdl.metadata.address,
       provider
     );
+  }
+ 
+  /**
+   * Build a ClockworkProvider from an AnchorProvider
+   *
+   * @param authority thread authority
+   */
+  static fromAnchorProvider(provider: anchor.AnchorProvider): ClockworkProvider {
+    const clockworkProvider = new ClockworkProvider(
+      provider.wallet,
+      provider.connection,
+      provider.opts
+    );
+    return clockworkProvider;
   }
 
   /**

--- a/tests/ThreadProgram.test.ts
+++ b/tests/ThreadProgram.test.ts
@@ -8,12 +8,13 @@ import {
 } from "@solana/web3.js";
 import { ClockworkProvider } from "../src";
 import { assert } from "chai";
-import { BN } from "@coral-xyz/anchor";
+import { BN, AnchorProvider} from "@coral-xyz/anchor";
 
 describe("Testing Thread Program", () => {
   const wallet = new NodeWallet(new Keypair());
   const connection = new Connection(clusterApiUrl("devnet"));
-  const provider = new ClockworkProvider(wallet, connection);
+  const anchorProvider = new AnchorProvider(connection, wallet, AnchorProvider.defaultOptions());
+  const provider = ClockworkProvider.fromAnchorProvider(anchorProvider);
   let threadPubkey: PublicKey;
 
   it("Airdrop", async () => {


### PR DESCRIPTION
…allet, adds factory method fromAnchorProvider()

Fixes: https://github.com/clockwork-xyz/sdk/issues/4